### PR TITLE
feat: use mathieudutour/github-tag-action

### DIFF
--- a/.github/workflows/uipath-flow.yml
+++ b/.github/workflows/uipath-flow.yml
@@ -77,7 +77,7 @@ jobs:
       
   tag:
     runs-on: ubuntu-latest
-    needs: [check-dependencies,analyze,test]
+    needs: [check-dependencies,analyze]
     outputs: 
       release_tag: ${{ steps.bump_tag.outputs.new_version }}
       release_upload_url: ${{ steps.automatic_release.outputs.upload_url }}

--- a/.github/workflows/uipath-flow.yml
+++ b/.github/workflows/uipath-flow.yml
@@ -46,39 +46,6 @@ jobs:
           orchestratorApplicationScope: ${{ secrets.orchestratorApplicationScope }}
           orchestratorLogicalName: ${{ secrets.organizationId }} 
 
-  check-dependencies:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-      - uses: Mikael-RnD/uipath-check-prerelease-dependencies@main
-      
-  tag:
-    runs-on: ubuntu-latest
-    needs: [check-dependencies,analyze]
-    outputs: 
-      release_tag: ${{ steps.bump_tag.outputs.new_version }}
-      release_upload_url: ${{ steps.automatic_release.outputs.upload_url }}
-    steps: 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-        
-      - run: echo Triggered by ${{ github.event_name }} event  
-        
-      - id: bump_tag
-        name: Github Tag with semantic versioning
-      # You may pin to the exact commit or the version.
-      # uses: hennejg/github-tag-action@2cd21a8413aa58e36a69cb22e64d5ad20aeb9b99
-        uses: hennejg/github-tag-action@v4.3.1
-        with:
-          # Required for permission to tag the repo.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Comma separated list of branches (bash reg exp accepted) that will generate the release tags. Other branches and pull-requests generate versions postfixed with the commit hash and do not generate any tag. Examples: `master` or `.*` or `release.*,hotfix.*,master`...
-          release_branches: "main,master"
-
-      #- run: echo new_tag ${{ steps.bump_tag.outputs.new_tag }} tag ${{ steps.bump_tag.outputs.tag }}
  
  # Run unit tests in project
   test:
@@ -99,7 +66,35 @@ jobs:
           orchestratorApplicationSecret: ${{ secrets.orchestratorApplicationSecret }}
           orchestratorApplicationScope: ${{ secrets.orchestratorApplicationScope }}
           orchestratorLogicalName: ${{ secrets.organizationId }} 
-          
+
+  check-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - uses: Mikael-RnD/uipath-check-prerelease-dependencies@main
+      
+  tag:
+    runs-on: ubuntu-latest
+    needs: [check-dependencies,analyze,test]
+    outputs: 
+      release_tag: ${{ steps.bump_tag.outputs.new_version }}
+      release_upload_url: ${{ steps.automatic_release.outputs.upload_url }}
+    steps: 
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+        
+      - run: echo Triggered by ${{ github.event_name }} event  
+        
+      - id: bump_tag
+        name: Github Tag with semantic versioning
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      #- run: echo new_tag ${{ steps.bump_tag.outputs.new_tag }} tag ${{ steps.bump_tag.outputs.tag }}
           
   # This workflow contains a single job called "build"
   build:


### PR DESCRIPTION
 

**What:** Switch action for tagging.

**How:**

**Why:** mathieudutour/github-tag-action does not require docker, which enables functionality on more environments
